### PR TITLE
fix: eliminate file write race condition (#54)

### DIFF
--- a/src/alaya/tools/_locks.py
+++ b/src/alaya/tools/_locks.py
@@ -1,0 +1,41 @@
+"""Per-path file locks for atomic read-modify-write operations.
+
+All vault file writes acquire a per-path lock so concurrent MCP tool calls
+(FastMCP dispatches sync tools to a thread pool) cannot interleave reads and
+writes on the same file.
+
+Only protects within a single process — sufficient for the MCP server model.
+"""
+import threading
+from pathlib import Path
+
+_registry_lock = threading.Lock()
+_path_locks: dict[Path, threading.Lock] = {}
+
+
+def get_path_lock(path: Path) -> threading.Lock:
+    """Return the lock for *path*, creating it if needed.
+
+    Uses path.resolve() so that relative and absolute references to the
+    same file share a single lock.
+    """
+    resolved = path.resolve()
+    with _registry_lock:
+        if resolved not in _path_locks:
+            _path_locks[resolved] = threading.Lock()
+        return _path_locks[resolved]
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via a sibling temp file.
+
+    On POSIX, os.replace() is guaranteed atomic when src and dst are on the
+    same filesystem (which is always true for a sibling temp file).
+    """
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(content)
+        tmp.replace(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise


### PR DESCRIPTION
## Summary

- Adds `src/alaya/tools/_locks.py` with a per-path `threading.Lock` registry and `atomic_write()` (temp-file + `os.replace()` for crash-safe POSIX atomicity)
- Wraps all read-modify-write cycles in `write.py`, `edit.py`, `inbox.py`, and `structure.py` with `get_path_lock(path)` so concurrent MCP tool calls are serialized per-file
- Replaces all `path.write_text()` calls inside lock blocks with `atomic_write()` so external editors (Obsidian/VSCode) always reload a complete file

## Test plan

- [x] Previously failing `test_concurrent_append_no_data_loss` now passes
- [x] New: `test_concurrent_update_tags_no_data_loss` — two threads adding different tags, both survive
- [x] New: `test_concurrent_replace_section_no_data_loss` — two threads replacing different sections, both survive
- [x] Full suite: 355/355 passed

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)