### PR TITLE
fix: block path traversal in ingest_tool (#56)

### DIFF
--- a/src/alaya/tools/ingest.py
+++ b/src/alaya/tools/ingest.py
@@ -176,6 +176,18 @@ def ingest(
         if not path.is_absolute():
             path = vault / source
 
+        # Reject paths that escape the vault root (traversal or absolute paths
+        # outside the vault such as /etc/passwd or ~/.ssh/id_rsa)
+        try:
+            path.resolve().relative_to(vault.resolve())
+        except ValueError:
+            return IngestResult(
+                title=source.split("/")[-1],
+                source=source,
+                raw_text=f"Path escapes vault root: {source}",
+                chunks_indexed=0,
+            )
+
         suffix = path.suffix.lower()
         resolved_title = title or path.stem
 


### PR DESCRIPTION
## Summary

- Adds a vault boundary check in the file path branch of `ingest()`: resolves the path and calls `.relative_to(vault.resolve())` before any file read — same pattern used by every other tool via `resolve_note_path()`
- Returns an error `IngestResult` (not an exception) for out-of-vault paths so the MCP caller gets a clean error message
- Fixes existing PDF tests that were writing to `tmp_path` (outside the vault) — moved to `vault/raw/`

## Test plan

- [x] `test_absolute_path_outside_vault_blocked` — `/etc/passwd` returns error result
- [x] `test_relative_traversal_outside_vault_blocked` — `../../etc/passwd` blocked
- [x] `test_absolute_path_inside_vault_allowed` — absolute path to vault file works
- [x] `test_relative_path_inside_vault_allowed` — relative vault path works
- [x] `test_ssh_key_path_blocked` — file clearly outside vault blocked
- [x] All 374 tests pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)