### PR TITLE
refactor: Phase 2 architecture improvements (#63 #64 #65 #66 #68 #69)

### DIFF
--- a/src/alaya/errors.py
+++ b/src/alaya/errors.py
@@ -6,16 +6,31 @@ these and return structured error strings for Claude to parse.
 
 Error string format: "ERROR [{CODE}]: {message}"
 """
-
-NOT_FOUND = "NOT_FOUND"
-ALREADY_EXISTS = "ALREADY_EXISTS"
-OUTSIDE_VAULT = "OUTSIDE_VAULT"
-SECTION_NOT_FOUND = "SECTION_NOT_FOUND"
-CONFIRMATION_REQUIRED = "CONFIRMATION_REQUIRED"
-NOT_CONFIGURED = "NOT_CONFIGURED"
-INVALID_ARGUMENT = "INVALID_ARGUMENT"
+from enum import Enum
 
 
-def error(code: str, message: str) -> str:
+class ErrorCode(str, Enum):
+    NOT_FOUND = "NOT_FOUND"
+    ALREADY_EXISTS = "ALREADY_EXISTS"
+    OUTSIDE_VAULT = "OUTSIDE_VAULT"
+    SECTION_NOT_FOUND = "SECTION_NOT_FOUND"
+    CONFIRMATION_REQUIRED = "CONFIRMATION_REQUIRED"
+    NOT_CONFIGURED = "NOT_CONFIGURED"
+    INVALID_ARGUMENT = "INVALID_ARGUMENT"
+
+
+# Re-export bare names for backwards-compatibility with all import sites.
+# Tool modules import e.g. `from alaya.errors import NOT_FOUND` — these
+# assignments make that work without changing every callsite.
+NOT_FOUND = ErrorCode.NOT_FOUND
+ALREADY_EXISTS = ErrorCode.ALREADY_EXISTS
+OUTSIDE_VAULT = ErrorCode.OUTSIDE_VAULT
+SECTION_NOT_FOUND = ErrorCode.SECTION_NOT_FOUND
+CONFIRMATION_REQUIRED = ErrorCode.CONFIRMATION_REQUIRED
+NOT_CONFIGURED = ErrorCode.NOT_CONFIGURED
+INVALID_ARGUMENT = ErrorCode.INVALID_ARGUMENT
+
+
+def error(code: ErrorCode, message: str) -> str:
     """Format a structured error string for tool return values."""
-    return f"ERROR [{code}]: {message}"
+    return f"ERROR [{code.value}]: {message}"

--- a/src/alaya/events.py
+++ b/src/alaya/events.py
@@ -3,14 +3,22 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Callable
+
+
+class EventType(Enum):
+    CREATED = auto()
+    MODIFIED = auto()
+    DELETED = auto()
+    MOVED = auto()
 
 
 @dataclass
 class NoteEvent:
-    event_type: str  # "created", "modified", "deleted", "moved"
+    event_type: EventType
     path: str        # relative path of the affected note
-    old_path: str | None = None  # set only for "moved" events
+    old_path: str | None = None  # set only for MOVED events
 
 
 _listeners: list[Callable[[NoteEvent], None]] = []

--- a/src/alaya/tools/providers/__init__.py
+++ b/src/alaya/tools/providers/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Callable, Protocol
 
 
 @dataclass
@@ -21,22 +21,42 @@ class Provider(Protocol):
     def create_item(self, title: str, body: str, labels: list[str]) -> str: ...  # returns URL
 
 
+_PROVIDER_FACTORIES: dict[str, Callable[[], Provider]] = {}
+# url_pattern -> provider name; checked as substring of lowercased source
+_URL_PATTERNS: dict[str, str] = {}
+
+
+def register_provider(name: str, factory: Callable[[], Provider], url_pattern: str) -> None:
+    """Register a provider factory and its URL pattern for auto-detection."""
+    _PROVIDER_FACTORIES[name] = factory
+    _URL_PATTERNS[url_pattern] = name
+
+
 def detect_provider(source: str) -> str | None:
     """Detect provider name from URL or shorthand like 'gitlab:open'."""
     lower = source.lower()
-    if "gitlab.com" in lower or lower.startswith("gitlab:"):
-        return "gitlab"
-    if "github.com" in lower or lower.startswith("github:"):
-        return "github"
+    for pattern, name in _URL_PATTERNS.items():
+        if pattern in lower or lower.startswith(f"{name}:"):
+            return name
     return None
 
 
 def get_provider(name: str) -> Provider:
     """Return a provider instance by name. Raises ValueError if unknown."""
-    if name == "gitlab":
-        from alaya.tools.providers.gitlab import GitLabProvider
-        return GitLabProvider()
-    if name == "github":
-        from alaya.tools.providers.github import GitHubProvider
-        return GitHubProvider()
-    raise ValueError(f"Unsupported provider: {name!r}. Supported: gitlab, github")
+    factory = _PROVIDER_FACTORIES.get(name)
+    if not factory:
+        supported = sorted(_PROVIDER_FACTORIES)
+        raise ValueError(f"Unsupported provider: {name!r}. Supported: {supported}")
+    return factory()
+
+
+# Register built-in providers. Imports are deferred so the registry module
+# itself has no heavy dependencies at import time.
+def _register_builtins() -> None:
+    from alaya.tools.providers.gitlab import GitLabProvider
+    from alaya.tools.providers.github import GitHubProvider
+    register_provider("gitlab", GitLabProvider, "gitlab.com")
+    register_provider("github", GitHubProvider, "github.com")
+
+
+_register_builtins()

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -16,5 +16,5 @@ def test_error_codes_are_strings() -> None:
 
 def test_error_contains_code_and_message() -> None:
     result = error(ALREADY_EXISTS, "some message")
-    assert f"[{ALREADY_EXISTS}]" in result
+    assert f"[{ALREADY_EXISTS.value}]" in result
     assert "some message" in result


### PR DESCRIPTION
## Summary

- **#63** `EventType` enum + exhaustive `match/case` with `_unreachable()` in server.py — compiler-friendly dispatch that catches unhandled variants at runtime
- **#64** `ErrorCode(str, Enum)` replaces bare string constants; bare-name re-exports keep all existing import sites unchanged
- **#65** Provider registry dict (`_PROVIDER_FACTORIES`, `_URL_PATTERNS`) replaces `if/elif` in `providers/__init__.py`; new providers register via `register_provider()`
- **#66** `delete_note` archive check uses `is_relative_to()` instead of the fragile `try/except relative_to` pattern
- **#68** `_tsv(line, count)` helper in `read.py` replaces four identical TSV-split-and-pad patterns
- **#69** Remove `_VALID_DIRS` allowlist from `write.py`; `_validate_directory` now only enforces vault boundary containment

## Test plan

- [x] `uv run pytest` — 392/392 passing
- [x] `test_errors.py` updated to use `.value` for f-string formatting (Python 3.12 `str` enum behaviour)
- [x] `test_events.py` updated to use `EventType.*` members

🤖 Generated with [Claude Code](https://claude.com/claude-code)