### PR TITLE
fix: resilient vault scans — skip hidden dirs, handle per-file errors (#67)

### DIFF
--- a/src/alaya/tools/external.py
+++ b/src/alaya/tools/external.py
@@ -137,9 +137,8 @@ def push_external(
 
 def _find_note_by_url(url: str, vault: Path) -> str | None:
     """Return the relative path of the first note containing the URL, or None."""
-    for md_file in vault.rglob("*.md"):
-        if ".zk" in md_file.parts:
-            continue
+    from alaya.tools.structure import _iter_vault_md
+    for md_file in _iter_vault_md(vault):
         try:
             if url in md_file.read_text():
                 return str(md_file.relative_to(vault))

--- a/src/alaya/tools/read.py
+++ b/src/alaya/tools/read.py
@@ -65,9 +65,10 @@ def get_note_by_title(title: str, vault: Path) -> str:
 
     Raises FileNotFoundError if no match, ValueError if multiple matches.
     """
+    from alaya.tools.structure import _iter_vault_md
     title_lower = title.lower()
     matches = []
-    for md_file in vault.rglob("*.md"):
+    for md_file in _iter_vault_md(vault):
         try:
             content = md_file.read_text()
         except OSError:


### PR DESCRIPTION
## Summary

- Add `_iter_vault_md(vault)` helper in `structure.py` — skips `.git`, `.zk`, `.venv`, `__pycache__` dirs; single place to update if more skip-dirs are needed
- `find_and_replace_wikilinks`: catches `OSError` per file, logs warning, continues instead of aborting mid-vault
- `find_references`: same error handling
- `_find_note_by_url` (external.py): was only skipping `.zk`; now reuses `_iter_vault_md`
- `get_note_by_title` (read.py): reuses `_iter_vault_md`

## Test plan

- [x] `test_unreadable_file_does_not_crash_scan` — chmod 000 file, scan completes
- [x] `test_skip_dirs_excluded_from_scan` — `.git`/`.zk` files not yielded
- [x] `test_unreadable_file_does_not_abort` — wikilink replace survives unreadable file
- [x] 396/396 passing

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)