### PR TITLE
feat: zk version check at startup (#77)

### DIFF
--- a/src/alaya/server.py
+++ b/src/alaya/server.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -120,7 +121,19 @@ def _register_health_tool(vault: Path) -> None:
         return "\n".join(lines)
 
 
+def _check_zk() -> None:
+    """Verify zk is installed and log its version. Exits with a clear message if not found."""
+    try:
+        result = subprocess.run(["zk", "--version"], capture_output=True, text=True, timeout=5)
+        logger.info("zk version: %s", result.stdout.strip())
+    except FileNotFoundError:
+        logger.error("zk CLI not found — install from: https://github.com/zk-org/zk")
+        raise SystemExit(1)
+
+
 def main() -> None:
+    _check_zk()
+
     try:
         vault_root = get_vault_root()
     except ConfigError as e:

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -1,0 +1,20 @@
+"""Tests for server startup checks."""
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from alaya.server import _check_zk
+
+
+def test_check_zk_succeeds_when_installed():
+    mock_result = subprocess.CompletedProcess(args=["zk", "--version"], returncode=0, stdout="zk 0.14.0\n", stderr="")
+    with patch("subprocess.run", return_value=mock_result):
+        _check_zk()  # should not raise
+
+
+def test_check_zk_exits_when_not_installed():
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(SystemExit) as exc_info:
+            _check_zk()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

- Add `_check_zk()` in `server.py`, called at the top of `main()` before vault config
- Runs `zk --version`, logs the version on success
- On `FileNotFoundError`: logs a clear error with install URL and exits with code 1 instead of letting the first tool call produce a cryptic stack trace

## Test plan

- [x] `test_check_zk_succeeds_when_installed` — mocked zk present, no exception
- [x] `test_check_zk_exits_when_not_installed` — `FileNotFoundError` → `SystemExit(1)`
- [x] 398/398 passing

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)