### PR TITLE
feat: vault_stats tool (#74)

### DIFF
--- a/src/alaya/server.py
+++ b/src/alaya/server.py
@@ -22,7 +22,7 @@ mcp = FastMCP(
 
 # Explicit registration: server -> tools (one direction only).
 # vault is resolved once here and closed over in each tool wrapper.
-from alaya.tools import read, write, inbox, search, structure, edit, tasks, external, ingest  # noqa: E402
+from alaya.tools import read, write, inbox, search, structure, edit, tasks, external, ingest, stats  # noqa: E402
 
 def _register_all(vault: Path) -> None:
     read._register(mcp, vault)
@@ -34,6 +34,7 @@ def _register_all(vault: Path) -> None:
     tasks._register(mcp, vault)
     external._register(mcp, vault)
     ingest._register(mcp, vault)
+    stats._register(mcp, vault)
 
 
 def _register_index_listener(vault: Path, watcher_handler=None) -> None:

--- a/src/alaya/tools/stats.py
+++ b/src/alaya/tools/stats.py
@@ -1,0 +1,67 @@
+"""Stats tool: vault_stats."""
+from collections import Counter
+from pathlib import Path
+
+from fastmcp import FastMCP
+from alaya.vault import parse_note
+from alaya.tools.structure import _iter_vault_md
+
+
+def vault_stats(vault: Path) -> str:
+    """Return a structured overview of the vault: note counts, directories, tags, index chunks."""
+    md_files = list(_iter_vault_md(vault))
+    total = len(md_files)
+
+    if total == 0:
+        return "Vault is empty — no notes found."
+
+    # Notes per top-level directory
+    dir_counts: Counter = Counter()
+    tag_counts: Counter = Counter()
+
+    for md_file in md_files:
+        rel = md_file.relative_to(vault)
+        top_dir = rel.parts[0] if len(rel.parts) > 1 else "(root)"
+        dir_counts[top_dir] += 1
+
+        try:
+            note = parse_note(md_file.read_text())
+            for tag in note.tags:
+                tag_counts[tag] += 1
+        except OSError:
+            pass
+
+    # Index chunk count (best-effort; 0 if index not initialised)
+    chunk_count = 0
+    try:
+        from alaya.index.store import get_store
+        store = get_store(vault)
+        chunk_count = len(store._get_table().search().limit(100_000).to_list())
+    except Exception:
+        pass
+
+    lines = [f"Vault: {total} note{'s' if total != 1 else ''} across {len(dir_counts)} director{'ies' if len(dir_counts) != 1 else 'y'}"]
+    if chunk_count:
+        lines.append(f"Index: {chunk_count:,} chunks")
+    lines.append("")
+
+    lines.append("Notes by directory:")
+    for d, count in sorted(dir_counts.items(), key=lambda x: -x[1]):
+        lines.append(f"  {d:<20} {count}")
+
+    if tag_counts:
+        lines.append("")
+        lines.append("Top tags:")
+        for tag, count in tag_counts.most_common(15):
+            lines.append(f"  #{tag:<19} {count}")
+
+    return "\n".join(lines)
+
+
+# --- FastMCP tool registration ---
+
+def _register(mcp: FastMCP, vault: Path) -> None:
+    @mcp.tool()
+    def vault_stats_tool() -> str:
+        """Return vault statistics: note counts by directory, top tags, and index coverage."""
+        return vault_stats(vault)

--- a/tests/unit/tools/test_stats.py
+++ b/tests/unit/tools/test_stats.py
@@ -1,0 +1,39 @@
+"""Unit tests for vault_stats tool."""
+from pathlib import Path
+
+import pytest
+
+from alaya.tools.stats import vault_stats
+
+
+class TestVaultStats:
+    def test_returns_note_count(self, vault: Path) -> None:
+        result = vault_stats(vault)
+        assert "note" in result
+
+    def test_lists_directories(self, vault: Path) -> None:
+        result = vault_stats(vault)
+        assert "Notes by directory:" in result
+        # fixture has ideas/ and projects/ directories
+        assert "ideas" in result
+        assert "projects" in result
+
+    def test_lists_top_tags(self, vault: Path) -> None:
+        result = vault_stats(vault)
+        # fixture notes have tags; section should appear
+        assert "Top tags:" in result
+
+    def test_empty_vault(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty_vault"
+        empty.mkdir()
+        result = vault_stats(empty)
+        assert "empty" in result.lower()
+
+    def test_vault_with_no_tags(self, tmp_path: Path) -> None:
+        solo = tmp_path / "solo_vault"
+        solo.mkdir()
+        note = solo / "note.md"
+        note.write_text("---\ntitle: Untagged\ndate: 2026-01-01\n---\nBody.\n")
+        result = vault_stats(solo)
+        assert "1 note" in result
+        assert "Top tags:" not in result


### PR DESCRIPTION
## Summary

- New `tools/stats.py` with `vault_stats(vault)` — total notes, breakdown by top-level directory, top 15 tags, LanceDB chunk count (best-effort)
- Registered in `_register_all()` in server.py
- Handles empty vault and notes with no tags gracefully

## Test plan

- [x] Returns note count, directory list, tag section on fixture vault
- [x] Returns "empty" message on empty vault
- [x] No "Top tags:" section when notes have no tags
- [x] 403/403 passing

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)