### PR TITLE
feat: vault_graph tool — link graph as JSON (#76)

### DIFF
--- a/src/alaya/server.py
+++ b/src/alaya/server.py
@@ -22,7 +22,7 @@ mcp = FastMCP(
 
 # Explicit registration: server -> tools (one direction only).
 # vault is resolved once here and closed over in each tool wrapper.
-from alaya.tools import read, write, inbox, search, structure, edit, tasks, external, ingest, stats  # noqa: E402
+from alaya.tools import read, write, inbox, search, structure, edit, tasks, external, ingest, stats, graph  # noqa: E402
 
 def _register_all(vault: Path) -> None:
     read._register(mcp, vault)
@@ -35,6 +35,7 @@ def _register_all(vault: Path) -> None:
     external._register(mcp, vault)
     ingest._register(mcp, vault)
     stats._register(mcp, vault)
+    graph._register(mcp, vault)
 
 
 def _register_index_listener(vault: Path, watcher_handler=None) -> None:

--- a/src/alaya/tools/graph.py
+++ b/src/alaya/tools/graph.py
@@ -1,0 +1,96 @@
+"""Graph tool: vault_graph."""
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+from fastmcp import FastMCP
+from alaya.vault import parse_note
+from alaya.tools.structure import _iter_vault_md
+
+# Matches [[Title]] and [[Title|alias]]
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+
+
+def vault_graph(vault: Path, directory: str = "", max_nodes: int = 200) -> str:
+    """Return the vault's wikilink graph as JSON.
+
+    Includes node count, edge count, orphan notes (nothing links to them),
+    and hub notes (most linked-to). Useful for understanding knowledge topology.
+    """
+    nodes: dict[str, dict] = {}  # rel_path -> metadata
+    edges: list[tuple[str, str]] = []  # (source_path, target_title)
+
+    for md_file in _iter_vault_md(vault):
+        rel = str(md_file.relative_to(vault))
+
+        if directory and not rel.startswith(directory.rstrip("/") + "/"):
+            continue
+        if len(nodes) >= max_nodes:
+            break
+
+        try:
+            content = md_file.read_text()
+        except OSError:
+            continue
+
+        note = parse_note(content)
+        top_dir = rel.split("/")[0] if "/" in rel else ""
+        nodes[rel] = {
+            "title": note.title or md_file.stem,
+            "tags": note.tags,
+            "directory": top_dir,
+        }
+
+        for match in _WIKILINK_RE.finditer(content):
+            edges.append((rel, match.group(1).strip()))
+
+    # Build title -> path lookup for resolving wikilinks
+    title_to_path = {meta["title"]: path for path, meta in nodes.items()}
+
+    # Resolve edges to paths where possible; count in-links per node
+    inlink_counts: Counter = Counter()
+    resolved_edges = []
+    for src, target_title in edges:
+        target_path = title_to_path.get(target_title)
+        resolved_edges.append({"source": src, "target": target_path or target_title})
+        if target_path:
+            inlink_counts[target_path] += 1
+
+    # Orphans: notes with zero inlinks AND zero outlinks to known nodes
+    outlink_set = {src for src, _ in edges}
+    orphans = [
+        path for path in nodes
+        if inlink_counts[path] == 0 and path not in outlink_set
+    ]
+
+    # Hubs: top 10 most linked-to
+    hubs = [
+        {"path": path, "title": nodes[path]["title"], "inlinks": count}
+        for path, count in inlink_counts.most_common(10)
+        if path in nodes
+    ]
+
+    truncated = len(nodes) >= max_nodes
+
+    return json.dumps({
+        "node_count": len(nodes),
+        "edge_count": len(resolved_edges),
+        "orphan_count": len(orphans),
+        "orphans": orphans[:20],
+        "hubs": hubs,
+        "truncated": truncated,
+    }, indent=2)
+
+
+# --- FastMCP tool registration ---
+
+def _register(mcp: FastMCP, vault: Path) -> None:
+    @mcp.tool()
+    def vault_graph_tool(directory: str = "", max_nodes: int = 200) -> str:
+        """Return the vault's wikilink graph as JSON. Finds orphan notes and hub topics.
+
+        directory: limit to notes under this directory (optional).
+        max_nodes: cap on nodes scanned (default 200).
+        """
+        return vault_graph(vault, directory=directory, max_nodes=max_nodes)

--- a/tests/unit/tools/test_graph.py
+++ b/tests/unit/tools/test_graph.py
@@ -1,0 +1,83 @@
+"""Unit tests for vault_graph tool."""
+import json
+from pathlib import Path
+
+import pytest
+
+from alaya.tools.graph import vault_graph
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    root = tmp_path / "graph_vault"
+    root.mkdir()
+    (root / "notes").mkdir()
+
+    # hub: linked to by two others
+    (root / "notes" / "hub.md").write_text(
+        "---\ntitle: Hub\ndate: 2026-01-01\n---\nCentral note.\n"
+    )
+    (root / "notes" / "a.md").write_text(
+        "---\ntitle: A\ndate: 2026-01-01\n---\nSee [[Hub]].\n"
+    )
+    (root / "notes" / "b.md").write_text(
+        "---\ntitle: B\ndate: 2026-01-01\n---\nAlso [[Hub]] and [[A]].\n"
+    )
+    # orphan: no links in or out
+    (root / "notes" / "orphan.md").write_text(
+        "---\ntitle: Orphan\ndate: 2026-01-01\n---\nStands alone.\n"
+    )
+    return root
+
+
+class TestVaultGraph:
+    def test_returns_valid_json(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        result = vault_graph(vault)
+        data = json.loads(result)
+        assert "node_count" in data
+        assert "edge_count" in data
+        assert "orphan_count" in data
+
+    def test_counts_nodes_and_edges(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        data = json.loads(vault_graph(vault))
+        assert data["node_count"] == 4
+        assert data["edge_count"] == 3  # Hub, Hub, A
+
+    def test_detects_orphan(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        data = json.loads(vault_graph(vault))
+        assert data["orphan_count"] == 1
+        assert any("orphan" in p for p in data["orphans"])
+
+    def test_detects_hub(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        data = json.loads(vault_graph(vault))
+        assert data["hubs"][0]["title"] == "Hub"
+        assert data["hubs"][0]["inlinks"] == 2
+
+    def test_handles_wikilink_alias(self, tmp_path: Path) -> None:
+        vault = tmp_path / "alias_vault"
+        vault.mkdir()
+        (vault / "target.md").write_text("---\ntitle: Target\ndate: 2026-01-01\n---\n")
+        (vault / "source.md").write_text("---\ntitle: Source\ndate: 2026-01-01\n---\n[[Target|display text]]\n")
+        data = json.loads(vault_graph(vault))
+        assert data["edge_count"] == 1
+
+    def test_empty_vault(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        data = json.loads(vault_graph(empty))
+        assert data["node_count"] == 0
+        assert data["orphan_count"] == 0
+
+    def test_max_nodes_truncates(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        data = json.loads(vault_graph(vault, max_nodes=2))
+        assert data["node_count"] <= 2
+        assert data["truncated"] is True
+
+    def test_directory_filter(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        data = json.loads(vault_graph(vault, directory="notes"))
+        assert data["node_count"] == 4  # all are in notes/


### PR DESCRIPTION
## Summary

- New `tools/graph.py` with `vault_graph(vault, directory, max_nodes)`
- Returns JSON with: node count, edge count, orphan notes (zero inlinks and outlinks), top-10 hub notes (most linked-to), truncation flag
- Handles `[[Title|alias]]` wikilinks correctly
- `directory` filter and `max_nodes` cap for large vaults
- Registered in `_register_all()` in server.py

## Test plan

- [x] Valid JSON returned
- [x] Node/edge counts correct
- [x] Orphan detection works
- [x] Hub detection correct
- [x] Alias wikilinks handled
- [x] Empty vault graceful
- [x] `max_nodes` truncation
- [x] Directory filter
- [x] 411/411 passing

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)