### PR TITLE
feat: incremental reindex — skip unchanged files (#72)

### DIFF
--- a/src/alaya/index/reindex.py
+++ b/src/alaya/index/reindex.py
@@ -1,9 +1,15 @@
-"""Full vault reindex: enumerate all .md files, chunk, embed, write to LanceDB atomically."""
+"""Vault reindex: full rebuild and incremental (skip unchanged files)."""
 from __future__ import annotations
 
+import hashlib
+import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from alaya.index.embedder import chunk_note, embed_chunks
+from alaya.index.store import upsert_note, delete_note_from_index, get_store
+from alaya.tools.structure import _iter_vault_md
 
 
 @dataclass
@@ -11,6 +17,12 @@ class ReindexResult:
     notes_indexed: int
     chunks_created: int
     duration_seconds: float
+    notes_skipped: int = 0
+    notes_deleted: int = 0
+
+
+def _file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def reindex_all(vault_root: Path, store=None) -> ReindexResult:
@@ -18,9 +30,6 @@ def reindex_all(vault_root: Path, store=None) -> ReindexResult:
 
     Enumerates all .md files, chunks each one, embeds in batches, writes to store.
     """
-    from alaya.index.embedder import chunk_note, embed_chunks
-    from alaya.index.store import upsert_note, VaultStore, get_store
-
     if store is None:
         store = get_store(vault_root)
 
@@ -28,12 +37,7 @@ def reindex_all(vault_root: Path, store=None) -> ReindexResult:
     notes_indexed = 0
     chunks_created = 0
 
-    md_files = [
-        f for f in vault_root.rglob("*.md")
-        if ".zk" not in f.parts
-    ]
-
-    for md_file in md_files:
+    for md_file in _iter_vault_md(vault_root):
         rel = str(md_file.relative_to(vault_root))
         content = md_file.read_text()
         chunks = chunk_note(rel, content)
@@ -49,4 +53,75 @@ def reindex_all(vault_root: Path, store=None) -> ReindexResult:
         notes_indexed=notes_indexed,
         chunks_created=chunks_created,
         duration_seconds=round(duration, 2),
+    )
+
+
+def reindex_incremental(vault_root: Path, store=None) -> ReindexResult:
+    """Reindex only files that have changed since the last run.
+
+    Uses a JSON state file (.zk/index_state.json) to track mtime and content hash
+    per file. Skips files where mtime is unchanged (fast path), or where mtime
+    changed but hash is the same (touch without content change). Cleans up
+    deleted files from the index.
+    """
+    if store is None:
+        store = get_store(vault_root)
+
+    state_file = vault_root / ".zk" / "index_state.json"
+    prev_state: dict = json.loads(state_file.read_text()) if state_file.exists() else {}
+
+    new_state: dict = {}
+    notes_indexed = 0
+    chunks_created = 0
+    notes_skipped = 0
+    start = time.monotonic()
+
+    for md_file in _iter_vault_md(vault_root):
+        rel = str(md_file.relative_to(vault_root))
+        try:
+            mtime = md_file.stat().st_mtime
+        except OSError:
+            continue
+
+        prev = prev_state.get(rel)
+
+        # Fast path: mtime unchanged — definitely not modified
+        if prev and prev.get("mtime") == mtime:
+            new_state[rel] = prev
+            notes_skipped += 1
+            continue
+
+        # Slow path: mtime changed — check hash before paying embedding cost
+        file_hash = _file_hash(md_file)
+        if prev and prev.get("hash") == file_hash:
+            new_state[rel] = {"mtime": mtime, "hash": file_hash}
+            notes_skipped += 1
+            continue
+
+        # Content changed — re-embed
+        content = md_file.read_text()
+        chunks = chunk_note(rel, content)
+        if chunks:
+            embeddings = embed_chunks(chunks)
+            upsert_note(rel, chunks, embeddings, store)
+            chunks_created += len(chunks)
+            notes_indexed += 1
+
+        new_state[rel] = {"mtime": mtime, "hash": file_hash}
+
+    # Remove index entries for files no longer in the vault
+    deleted = set(prev_state) - set(new_state)
+    for old_path in deleted:
+        delete_note_from_index(old_path, store)
+
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(new_state, indent=2))
+
+    duration = time.monotonic() - start
+    return ReindexResult(
+        notes_indexed=notes_indexed,
+        chunks_created=chunks_created,
+        duration_seconds=round(duration, 2),
+        notes_skipped=notes_skipped,
+        notes_deleted=len(deleted),
     )

--- a/tests/unit/index/test_reindex.py
+++ b/tests/unit/index/test_reindex.py
@@ -1,0 +1,124 @@
+"""Tests for incremental reindex — skip unchanged, re-embed changed, delete removed."""
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+from alaya.index.reindex import reindex_incremental, reindex_all, ReindexResult
+
+
+def _make_note(path: Path, text: str = "Body text.") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntitle: Test\ndate: 2026-01-01\n---\n{text}\n")
+
+
+def _mock_embed(chunks):
+    return [np.zeros(768, dtype=np.float32) for _ in chunks]
+
+
+class TestReindexIncremental:
+    def test_first_run_indexes_all_files(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+        _make_note(vault / "b.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            result = reindex_incremental(vault)
+
+        assert result.notes_indexed == 2
+        assert result.notes_skipped == 0
+
+    def test_second_run_skips_unchanged(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)  # first run writes state
+            result = reindex_incremental(vault)  # second run: nothing changed
+
+        assert result.notes_indexed == 0
+        assert result.notes_skipped == 1
+
+    def test_changed_file_reindexed(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        note = vault / "a.md"
+        _make_note(note, "original")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)
+
+        # Change file content (also advances mtime)
+        note.write_text("---\ntitle: Test\ndate: 2026-01-01\n---\nupdated content\n")
+
+        embed_calls = []
+        def capture_embed(chunks):
+            embed_calls.append(chunks)
+            return _mock_embed(chunks)
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=capture_embed):
+            result = reindex_incremental(vault)
+
+        assert result.notes_indexed == 1
+        assert len(embed_calls) == 1
+
+    def test_deleted_file_removed_from_index(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        note = vault / "a.md"
+        _make_note(note)
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)
+
+        note.unlink()
+
+        deleted_paths = []
+        def capture_delete(path, store):
+            deleted_paths.append(path)
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.reindex.delete_note_from_index", side_effect=capture_delete):
+            result = reindex_incremental(vault)
+
+        assert result.notes_deleted == 1
+        assert "a.md" in deleted_paths[0]
+
+    def test_state_file_written_to_zk_dir(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)
+
+        state_file = vault / ".zk" / "index_state.json"
+        assert state_file.exists()
+
+    def test_result_includes_skipped_and_deleted_counts(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "keep.md")
+        _make_note(vault / "gone.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)
+
+        (vault / "gone.md").unlink()
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.reindex.delete_note_from_index"):
+            result = reindex_incremental(vault)
+
+        assert result.notes_skipped == 1
+        assert result.notes_deleted == 1
+        assert result.notes_indexed == 0

--- a/tests/unit/tools/test_search_m3.py
+++ b/tests/unit/tools/test_search_m3.py
@@ -48,14 +48,16 @@ class TestReindexVault:
         mock_result.notes_indexed = 12
         mock_result.chunks_created = 47
         mock_result.duration_seconds = 3.2
+        mock_result.notes_skipped = 5
+        mock_result.notes_deleted = 0
 
-        with patch("alaya.tools.read._run_reindex", return_value=mock_result):
+        with patch("alaya.index.reindex.reindex_incremental", return_value=mock_result):
             result = reindex_vault(vault, confirm=True)
 
         assert "12" in result
         assert "47" in result
 
     def test_reindex_error_returns_message(self, vault: Path) -> None:
-        with patch("alaya.tools.read._run_reindex", side_effect=Exception("disk full")):
+        with patch("alaya.index.reindex.reindex_incremental", side_effect=Exception("disk full")):
             result = reindex_vault(vault, confirm=True)
         assert "error" in result.lower() or "failed" in result.lower()


### PR DESCRIPTION
## Summary

- Add `reindex_incremental(vault_root, store)` in `reindex.py`
- State file at `.zk/index_state.json` tracks `{path: {mtime, hash}}` per note
- **Fast path**: mtime unchanged → skip entirely (no file read)
- **Slow path**: mtime changed, hash unchanged (touch) → update mtime, skip embed
- **Re-embed**: content hash changed → chunk + embed + upsert
- **Cleanup**: paths in old state but not in new → `delete_note_from_index`
- `reindex_vault_tool` now uses incremental by default; `force=True` runs full rebuild
- `ReindexResult` gains `notes_skipped` and `notes_deleted` fields

## Test plan

- [x] First run indexes all files
- [x] Second run (unchanged) skips all files
- [x] Modified file is re-indexed
- [x] Deleted file removed from index
- [x] State file written to `.zk/`
- [x] `notes_skipped` and `notes_deleted` counts correct
- [x] 421/421 passing

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)