### PR TITLE
feat: embedding model hot-swap with background re-embed (#78)

### DIFF
--- a/src/alaya/index/health.py
+++ b/src/alaya/index/health.py
@@ -7,6 +7,10 @@ import time
 # path -> (error_message, timestamp)
 _failed_paths: dict[str, tuple[str, float]] = {}
 _last_success_ts: float | None = None
+
+# Migration progress: set when a background model re-embed is running
+_migration: dict | None = None  # {from_model, to_model, total, done}
+
 _lock = threading.Lock()
 
 
@@ -22,20 +26,44 @@ def record_success(path: str) -> None:
         _last_success_ts = time.monotonic()
 
 
+def start_migration(from_model: str, to_model: str, total: int) -> None:
+    """Record that a background model migration has started."""
+    global _migration
+    with _lock:
+        _migration = {"from_model": from_model, "to_model": to_model, "total": total, "done": 0}
+
+
+def update_migration_progress(done: int) -> None:
+    """Update the count of notes re-embedded so far."""
+    with _lock:
+        if _migration is not None:
+            _migration["done"] = done
+
+
+def finish_migration() -> None:
+    """Mark migration as complete."""
+    global _migration
+    with _lock:
+        _migration = None
+
+
 def get_status() -> dict:
     """Return a consistent snapshot of current index health."""
     with _lock:
         failed = {path: msg for path, (msg, _) in _failed_paths.items()}
         last_ok = _last_success_ts
+        migration = dict(_migration) if _migration else None
     return {
         "failed_paths": failed,
         "last_success_ago_seconds": round(time.monotonic() - last_ok, 1) if last_ok else None,
+        "migration": migration,
     }
 
 
 def reset() -> None:
     """Clear all state. Intended for use in tests only."""
-    global _last_success_ts
+    global _last_success_ts, _migration
     with _lock:
         _failed_paths.clear()
         _last_success_ts = None
+        _migration = None

--- a/tests/unit/index/test_reindex.py
+++ b/tests/unit/index/test_reindex.py
@@ -1,11 +1,12 @@
 """Tests for incremental reindex — skip unchanged, re-embed changed, delete removed."""
+import json
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pytest
 
-from alaya.index.reindex import reindex_incremental, reindex_all, ReindexResult
+from alaya.index.reindex import reindex_incremental, reindex_all, reembed_background, ReindexResult
 
 
 def _make_note(path: Path, text: str = "Body text.") -> None:
@@ -122,3 +123,107 @@ class TestReindexIncremental:
         assert result.notes_skipped == 1
         assert result.notes_deleted == 1
         assert result.notes_indexed == 0
+
+
+class TestModelChangeDetection:
+    def test_model_change_forces_full_reindex(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        # First run with model-A
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.models.get_active_model") as mock_model:
+            mock_model.return_value = MagicMock(name="nomic-ai/model-a", dimensions=768)
+            mock_model.return_value.name = "model-a"
+            reindex_incremental(vault)
+
+        # Verify state file records model-a
+        state = json.loads((vault / ".zk" / "index_state.json").read_text())
+        assert state["_model"] == "model-a"
+
+        # Second run with model-B — should re-embed everything
+        embed_calls = []
+        def capture_embed(chunks):
+            embed_calls.extend(chunks)
+            return _mock_embed(chunks)
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=capture_embed), \
+             patch("alaya.index.models.get_active_model") as mock_model:
+            mock_model.return_value = MagicMock(name="nomic-ai/model-b", dimensions=768)
+            mock_model.return_value.name = "model-b"
+            result = reindex_incremental(vault)
+
+        assert result.notes_indexed == 1  # re-embedded despite no content change
+        assert result.notes_skipped == 0
+
+        # State file should now record model-b
+        state = json.loads((vault / ".zk" / "index_state.json").read_text())
+        assert state["_model"] == "model-b"
+
+    def test_same_model_skips_unchanged(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed):
+            reindex_incremental(vault)
+            result = reindex_incremental(vault)
+
+        assert result.notes_skipped == 1
+        assert result.notes_indexed == 0
+
+
+class TestReembedBackground:
+    def test_reembed_processes_all_notes(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+        _make_note(vault / "b.md")
+
+        upserted = []
+        def capture_upsert(path, chunks, embeddings, store):
+            upserted.append(path)
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.reindex.upsert_note", side_effect=capture_upsert), \
+             patch("alaya.index.reindex._REEMBED_SLEEP", 0):
+            reembed_background(vault, "old-model", "new-model")
+
+        assert len(upserted) == 2
+
+    def test_reembed_updates_health_migration(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        from alaya.index import health
+        health.reset()
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.reindex.upsert_note"), \
+             patch("alaya.index.reindex._REEMBED_SLEEP", 0):
+            reembed_background(vault, "old", "new")
+
+        # Migration should be finished
+        status = health.get_status()
+        assert status["migration"] is None  # finished
+
+    def test_reembed_writes_state_file(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / ".zk").mkdir()
+        _make_note(vault / "a.md")
+
+        with patch("alaya.index.reindex.embed_chunks", side_effect=_mock_embed), \
+             patch("alaya.index.reindex.upsert_note"), \
+             patch("alaya.index.reindex._REEMBED_SLEEP", 0):
+            reembed_background(vault, "old-model", "new-model")
+
+        state = json.loads((vault / ".zk" / "index_state.json").read_text())
+        assert state["_model"] == "new-model"
+        assert "a.md" in state["files"]

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -1,10 +1,12 @@
 """Tests for server startup checks."""
 import subprocess
-from unittest.mock import patch
+import threading
+from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import pytest
 
-from alaya.server import _check_zk
+from alaya.server import _check_zk, _maybe_start_reembed
 
 
 def test_check_zk_succeeds_when_installed():
@@ -18,3 +20,40 @@ def test_check_zk_exits_when_not_installed():
         with pytest.raises(SystemExit) as exc_info:
             _check_zk()
         assert exc_info.value.code == 1
+
+
+def test_maybe_start_reembed_no_op_when_models_match(tmp_path: Path) -> None:
+    store = MagicMock()
+    with patch("alaya.index.store.get_index_model", return_value="model-a"), \
+         patch("alaya.index.models.get_active_model") as mock_active:
+        mock_active.return_value.name = "model-a"
+        threads_before = threading.active_count()
+        _maybe_start_reembed(tmp_path, store)
+        assert threading.active_count() == threads_before
+
+
+def test_maybe_start_reembed_no_op_when_index_empty(tmp_path: Path) -> None:
+    store = MagicMock()
+    with patch("alaya.index.store.get_index_model", return_value=None), \
+         patch("alaya.index.models.get_active_model") as mock_active:
+        mock_active.return_value.name = "model-a"
+        threads_before = threading.active_count()
+        _maybe_start_reembed(tmp_path, store)
+        assert threading.active_count() == threads_before
+
+
+def test_maybe_start_reembed_spawns_thread_on_mismatch(tmp_path: Path) -> None:
+    store = MagicMock()
+    started = []
+
+    def fake_reembed(*args, **kwargs):
+        started.append(True)
+
+    with patch("alaya.index.store.get_index_model", return_value="old-model"), \
+         patch("alaya.index.models.get_active_model") as mock_active, \
+         patch("alaya.index.reindex.reembed_background", side_effect=fake_reembed):
+        mock_active.return_value.name = "new-model"
+        _maybe_start_reembed(tmp_path, store)
+        import time; time.sleep(0.05)
+
+    assert started


### PR DESCRIPTION
## Summary

**Problem:** Changing `ALAYA_EMBEDDING_MODEL` silently produced garbage search results until the user manually ran a full reindex.

**Changes:**

### `store.py`
- Added `embedding_model` column to LanceDB schema — each row records which model produced its vector
- `get_index_model()` reads the stored model from the first row; returns `None` on empty index or old schema
- `_get_table()` falls back to `open_table()` on schema mismatch so existing indexes without the column keep working
- `upsert_note()` skips the column on old-schema tables

### `health.py`
- `start_migration()`, `update_migration_progress()`, `finish_migration()` for live progress tracking
- `get_status()` now includes a `migration` field (null when idle)

### `reindex.py`
- `reindex_incremental()` stores `{"_model": "...", "files": {...}}` in `.zk/index_state.json`; treats any model change as all-files-dirty (full re-embed on next incremental run)
- `reembed_background(vault, from_model, to_model)` — re-embeds all notes in 20-note batches with 0.5s sleep between; updates health progress; writes state file when done

### `server.py`
- `_maybe_start_reembed()` called at startup; compares `get_index_model()` vs `get_active_model().name`; spawns a daemon thread on mismatch; no-ops when index is empty or models match

## Behaviour on model change
1. User sets `ALAYA_EMBEDDING_MODEL=nomic-v1.5-q4` and restarts
2. Server logs `WARNING: Embedding model changed: nomic-v1.5 -> nomic-v1.5-q4. Starting background re-embed.`
3. Search works immediately (degraded — old vectors are still queried)
4. Background thread re-embeds 20 notes at a time; `vault_health` shows migration progress
5. When done, all vectors are in the new space; state file updated

## Test plan
- [x] Model change forces full reindex on next incremental run
- [x] Same model skips unchanged files
- [x] `reembed_background` processes all notes, updates health, writes state file
- [x] `_maybe_start_reembed` no-ops when models match or index is empty
- [x] `_maybe_start_reembed` spawns thread on mismatch
- [x] Old-schema indexes (no `embedding_model` column) still work
- [x] 441/441 passing

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)