### PR TITLE
fix: remove empty env block in SAST workflow

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -31,9 +31,7 @@ jobs:
             --error \
             --sarif-output semgrep.sarif \
             src/
-        env:
-          # Optional: publish results to semgrep.dev dashboard
-          # SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        # To publish results to semgrep.dev, add SEMGREP_APP_TOKEN to repo secrets
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()


### PR DESCRIPTION
## Summary

- Removes the `env:` block that contained only comments — GitHub Actions treats it as an empty map and rejects the workflow file with "Unexpected value ''"
- Moves the `SEMGREP_APP_TOKEN` note to an inline comment on the run step instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)