### PR TITLE
fix: data corruption, security bugs, and semgrep improvements

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Run Semgrep (OSS rules)
         run: |
           semgrep scan \
+            --config p/default \
             --config p/python \
             --config p/owasp-top-ten \
+            --config p/security-audit \
             --config p/secrets \
             --config .semgrep/ \
             --sarif-output semgrep.sarif \

--- a/src/alaya/tools/ingest.py
+++ b/src/alaya/tools/ingest.py
@@ -194,6 +194,7 @@ def ingest(
     else:
         path = Path(source)
         if not path.is_absolute():
+            # nosemgrep: semgrep.alaya-path-traversal — validated by relative_to() on line 202
             path = vault / source
 
         # Reject paths that escape the vault root (traversal or absolute paths

--- a/src/alaya/tools/structure.py
+++ b/src/alaya/tools/structure.py
@@ -121,6 +121,7 @@ def rename_note(relative_path: str, new_title: str, vault: Path) -> str:
         fm_title_match = re.search(r"^title:\s*(.+)$", content, re.MULTILINE)
         old_title = fm_title_match.group(1).strip() if fm_title_match else src.stem
         new_slug = _slugify(new_title)
+        # nosemgrep: semgrep.alaya-path-traversal — src from resolve_note_path(), slug from _slugify()
         dest = src.parent / f"{new_slug}.md"
 
         # update frontmatter title then rename atomically

--- a/src/alaya/tools/tasks.py
+++ b/src/alaya/tools/tasks.py
@@ -25,6 +25,7 @@ def get_todos(
         search_roots = []
         vault_resolved = vault.resolve()
         for d in directories:
+            # nosemgrep: semgrep.alaya-path-traversal — validated by relative_to() on next line
             root = (vault / d).resolve()
             try:
                 root.relative_to(vault_resolved)

--- a/src/alaya/tools/write.py
+++ b/src/alaya/tools/write.py
@@ -34,6 +34,7 @@ def _check_duplicates(title: str, body: str, vault: Path, threshold: float = _DE
 
 def _validate_directory(directory: str, vault: Path) -> Path:
     """Resolve directory inside vault and reject path traversal."""
+    # nosemgrep: semgrep.alaya-path-traversal — this function IS the traversal validator
     target = (vault / directory).resolve()
     try:
         target.relative_to(vault.resolve())
@@ -56,7 +57,8 @@ _VALID_TAG_RE = re.compile(r"^[\w-]+$")
 def _load_template(vault: Path, name: str) -> str | None:
     """Load a template file from vault/templates/{name}.md, or None if not found."""
     templates_dir = (vault / "templates").resolve()
-    path = (templates_dir / f"{name}.md").resolve()  # nosemgrep: alaya-path-traversal
+    # nosemgrep: semgrep.alaya-path-traversal — validated by is_relative_to() on next line
+    path = (templates_dir / f"{name}.md").resolve()
     if not path.is_relative_to(templates_dir):
         raise ValueError(f"Template name {name!r} escapes templates directory")
     try:
@@ -141,6 +143,7 @@ def create_note(
     target_dir = _validate_directory(directory, vault)
     target_dir.mkdir(parents=True, exist_ok=True)
 
+    # nosemgrep: semgrep.alaya-path-traversal — target_dir from _validate_directory(), slug from _slugify()
     file_path = target_dir / f"{slug}.md"
     content = _build_note_content(title, tags, body, vault, directory, template)
 


### PR DESCRIPTION
## Summary
- **Thread-safety fixes**: Fix deadlock in `VaultStore` (double lock acquisition), protect watcher debounce timers with lock, isolate event listener failures
- **Security**: Fix path traversal in `_load_template`, fix SQL escaping in LanceDB filter expressions
- **Semgrep improvements**: Fix broken `alaya-lancedb-injection` rule structure, add `_sq_like()` exclusion, scope rules to relevant files, add `p/default` and `p/security-audit` rule packs, only block CI on ERROR-level findings
- **Code cleanup**: Extract `embed_query()` to deduplicate query embedding logic, move `iter_vault_md` to `vault` module, avoid double file reads in incremental reindex

## Test plan
- [x] All 377 unit tests pass
- [x] Semgrep custom rules scan clean (0 findings after suppressing validated false positives)
- [ ] Verify SAST CI job passes with new rule packs
- [ ] Verify no regressions in search/write/ingest flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)