### PR TITLE
fix: pass since date filter through to hybrid search

### DIFF
--- a/src/alaya/index/store.py
+++ b/src/alaya/index/store.py
@@ -202,6 +202,7 @@ def hybrid_search(
     store: VaultStore,
     directory: str | None = None,
     tags: list[str] | None = None,
+    since: str | None = None,
     limit: int = 10,
 ) -> list[dict]:
     """Vector ANN search with optional metadata pre-filter.
@@ -223,6 +224,8 @@ def hybrid_search(
             for tag in tags:
                 # tags column is comma-separated; match as substring
                 filters.append(f"tags LIKE '%{_sq_like(tag)}%'")
+        if since:
+            filters.append(f"modified_date >= '{_sq(since)}'")
         if filters:
             q = q.where(" AND ".join(filters))
 

--- a/src/alaya/tools/search.py
+++ b/src/alaya/tools/search.py
@@ -20,6 +20,7 @@ def _run_hybrid_search(
     vault: Path,
     directory: str | None = None,
     tags: list[str] | None = None,
+    since: str | None = None,
     limit: int = 20,
 ) -> list[dict]:
     """Embed the query and run hybrid search against LanceDB."""
@@ -28,7 +29,7 @@ def _run_hybrid_search(
 
     query_embedding = embed_query(query)
     store = get_store(vault)
-    return hybrid_search(query, query_embedding, store, directory=directory, tags=tags, limit=limit)
+    return hybrid_search(query, query_embedding, store, directory=directory, tags=tags, since=since, limit=limit)
 
 
 def search_notes(
@@ -45,7 +46,7 @@ def search_notes(
     zk keyword search otherwise.
     """
     if _hybrid_search_available(vault):
-        results = _run_hybrid_search(query, vault, directory=directory, tags=tags, limit=limit)
+        results = _run_hybrid_search(query, vault, directory=directory, tags=tags, since=since, limit=limit)
         if not results:
             return "No notes matching that query."
         rows = [


### PR DESCRIPTION
## Summary
- Wire the `since` parameter through `_run_hybrid_search` to `hybrid_search` in LanceDB store
- Previously `since` was silently ignored when hybrid search was active, only working with the zk keyword fallback
- Filters on the existing `modified_date` column with `>=` comparison

Closes #103 (last remaining item)

## Test plan
- [x] All 377 unit tests pass
- [ ] Verify `search_notes_tool` with `since` parameter returns only notes modified after the given date

🤖 Generated with [Claude Code](https://claude.com/claude-code)