### PR TITLE
fix: code review round 2 — data integrity, races, and identity bugs

### DIFF
--- a/src/alaya/index/embedder.py
+++ b/src/alaya/index/embedder.py
@@ -12,40 +12,40 @@ from alaya.index.models import get_active_model
 logger = logging.getLogger(__name__)
 
 _model = None
-_loaded_model_name: str | None = None  # track which model is loaded
-# Guards _model and _loaded_model_name against concurrent load by multiple threads
+_loaded_model_key: str | None = None  # track which model variant is loaded
+# Guards _model and _loaded_model_key against concurrent load by multiple threads
 # (e.g. watcher ingest thread + write-through event handler).
 _model_lock = threading.Lock()
 
 
 def get_model():
-    global _model, _loaded_model_name
+    global _model, _loaded_model_key
     cfg = get_active_model()
-    # Fast path: model already loaded and name matches — no lock needed for reads
+    # Fast path: model already loaded and key matches — no lock needed for reads
     # since CPython's GIL makes these reads atomic, and model identity is stable.
-    if _model is not None and _loaded_model_name == cfg.name:
+    if _model is not None and _loaded_model_key == cfg.key:
         return _model, cfg
     # Slow path: load under lock to prevent concurrent double-initialisation.
     with _model_lock:
         # Re-check after acquiring the lock (double-checked locking pattern).
-        if _model is None or _loaded_model_name != cfg.name:
-            logger.info("Loading embedding model: %s", cfg.name)
+        if _model is None or _loaded_model_key != cfg.key:
+            logger.info("Loading embedding model: %s (%s)", cfg.key, cfg.name)
             from fastembed import TextEmbedding
             kwargs = {}
             if cfg.file_name:
                 kwargs["model_file"] = cfg.file_name
             _model = TextEmbedding(cfg.name, **kwargs)
-            _loaded_model_name = cfg.name
+            _loaded_model_key = cfg.key
             logger.info("Embedding model loaded")
     return _model, cfg
 
 
 def reset_model() -> None:
     """Clear the cached model. Intended for use in tests only."""
-    global _model, _loaded_model_name
+    global _model, _loaded_model_key
     with _model_lock:
         _model = None
-        _loaded_model_name = None
+        _loaded_model_key = None
 
 
 @dataclass

--- a/src/alaya/index/models.py
+++ b/src/alaya/index/models.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class EmbeddingModelConfig:
-    name: str
+    key: str  # unique registry key used for identity comparisons
+    name: str  # HuggingFace model name passed to fastembed
     file_name: str | None
     dimensions: int
     search_prefix: str
@@ -16,6 +17,7 @@ class EmbeddingModelConfig:
 
 MODELS: dict[str, EmbeddingModelConfig] = {
     "nomic-v1.5": EmbeddingModelConfig(
+        key="nomic-v1.5",
         name="nomic-ai/nomic-embed-text-v1.5",
         file_name=None,  # fastembed default (model.onnx)
         dimensions=768,
@@ -23,6 +25,7 @@ MODELS: dict[str, EmbeddingModelConfig] = {
         document_prefix="search_document: ",
     ),
     "nomic-v1.5-q4": EmbeddingModelConfig(
+        key="nomic-v1.5-q4",
         name="nomic-ai/nomic-embed-text-v1.5",
         file_name="onnx/model_q4.onnx",
         dimensions=768,

--- a/src/alaya/index/reindex.py
+++ b/src/alaya/index/reindex.py
@@ -69,7 +69,7 @@ def reindex_incremental(vault_root: Path, store=None) -> ReindexResult:
     files from the index.
     """
     from alaya.index.models import get_active_model
-    active_model = get_active_model().name
+    active_model = get_active_model().key
 
     if store is None:
         store = get_store(vault_root)

--- a/src/alaya/index/store.py
+++ b/src/alaya/index/store.py
@@ -117,7 +117,7 @@ def upsert_note(
 ) -> None:
     """Replace all chunks for `path` with the new chunks + embeddings."""
     from alaya.index.models import get_active_model
-    active_model = get_active_model().name
+    active_model = get_active_model().key
 
     table = store._get_table()
 
@@ -176,8 +176,6 @@ def update_metadata(
         if not existing:
             return
 
-        table.delete(f"path = '{_sq(old_path)}'")
-
         updated = []
         for row in existing:
             row = dict(row)
@@ -191,7 +189,10 @@ def update_metadata(
             row.pop("_distance", None)
             updated.append(row)
 
+        # Add new rows before deleting old ones — brief duplication is
+        # harmless, but losing rows on a failed add is not recoverable.
         table.add(updated)
+        table.delete(f"path = '{_sq(old_path)}'")
     except _STORE_ERRORS as e:
         logger.warning("Failed to update metadata for %s: %s", old_path, e)
 

--- a/src/alaya/server.py
+++ b/src/alaya/server.py
@@ -141,7 +141,7 @@ def _maybe_start_reembed(vault_root, store) -> None:
     from alaya.index.reindex import reembed_background
 
     stored = get_index_model(store)
-    active = get_active_model().name
+    active = get_active_model().key
     if stored is None or stored == active:
         return
 

--- a/src/alaya/tools/_locks.py
+++ b/src/alaya/tools/_locks.py
@@ -6,6 +6,8 @@ writes on the same file.
 
 Only protects within a single process — sufficient for the MCP server model.
 """
+import os
+import tempfile
 import threading
 from pathlib import Path
 
@@ -32,8 +34,10 @@ def atomic_write(path: Path, content: str) -> None:
     On POSIX, os.replace() is guaranteed atomic when src and dst are on the
     same filesystem (which is always true for a sibling temp file).
     """
-    tmp = path.with_suffix(".tmp")
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    tmp = Path(tmp_name)
     try:
+        os.close(fd)
         tmp.write_text(content)
         tmp.replace(path)
     except Exception:

--- a/src/alaya/tools/structure.py
+++ b/src/alaya/tools/structure.py
@@ -7,7 +7,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 from fastmcp import FastMCP
-from alaya.errors import error, NOT_FOUND, OUTSIDE_VAULT, INVALID_ARGUMENT
+from alaya.errors import error, NOT_FOUND, OUTSIDE_VAULT, INVALID_ARGUMENT, ALREADY_EXISTS
 from alaya.events import emit, NoteEvent, EventType
 from alaya.vault import resolve_note_path, iter_vault_md as _iter_vault_md
 from alaya.tools.write import _validate_directory, _slugify
@@ -92,14 +92,13 @@ def move_note(relative_path: str, destination_dir: str, vault: Path) -> str:
     update wikilinks.
     """
     src = resolve_note_path(relative_path, vault)
-    if not src.exists():
-        raise FileNotFoundError(f"Note not found: {relative_path}")
-
     dest_dir = _validate_directory(destination_dir, vault)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / src.name
 
     with get_path_lock(src):
+        if not src.exists():
+            raise FileNotFoundError(f"Note not found: {relative_path}")
         shutil.move(str(src), str(dest))
     new_relative = str(dest.relative_to(vault))
     emit(NoteEvent(EventType.MOVED, new_relative, old_path=relative_path))
@@ -124,6 +123,8 @@ def rename_note(relative_path: str, new_title: str, vault: Path) -> str:
         new_slug = _slugify(new_title)
         # nosemgrep: semgrep.alaya-path-traversal — src from resolve_note_path(), slug from _slugify()
         dest = src.parent / f"{new_slug}.md"
+        if dest.exists() and dest != src:
+            raise FileExistsError(f"A note already exists at {dest.relative_to(vault)}")
 
         # update frontmatter title then rename atomically
         content = re.sub(r"^title:.*$", f"title: {new_title}", content, count=1, flags=re.MULTILINE)
@@ -144,22 +145,23 @@ def delete_note(relative_path: str, vault: Path, reason: str | None = None) -> s
     Raises ValueError if the note is already in archives/.
     """
     src = resolve_note_path(relative_path, vault)
-    if not src.exists():
-        raise FileNotFoundError(f"Note not found: {relative_path}")
+    archives_dir = vault / _ARCHIVES_DIR
+    archives_dir.mkdir(exist_ok=True)
 
-    if src.resolve().is_relative_to((vault / _ARCHIVES_DIR).resolve()):
-        raise ValueError(f"Note is already archived: {relative_path}")
+    with get_path_lock(src):
+        if not src.exists():
+            raise FileNotFoundError(f"Note not found: {relative_path}")
 
-    if reason:
-        with get_path_lock(src):
+        if src.resolve().is_relative_to((vault / _ARCHIVES_DIR).resolve()):
+            raise ValueError(f"Note is already archived: {relative_path}")
+
+        if reason:
             existing = src.read_text()
             atomic_write(src, _insert_frontmatter_field(existing, "archived_reason", reason))
 
-    archives_dir = vault / _ARCHIVES_DIR
-    archives_dir.mkdir(exist_ok=True)
-    dest = archives_dir / src.name
+        dest = archives_dir / src.name
+        shutil.move(str(src), str(dest))
 
-    shutil.move(str(src), str(dest))
     archive_relative = str(dest.relative_to(vault))
     emit(NoteEvent(EventType.DELETED, relative_path))
     return archive_relative
@@ -185,6 +187,8 @@ def _register(mcp: FastMCP, vault: Path) -> None:
             return rename_note(path, new_title, vault)
         except FileNotFoundError as e:
             return error(NOT_FOUND, str(e))
+        except FileExistsError as e:
+            return error(ALREADY_EXISTS, str(e))
         except ValueError as e:
             return error(OUTSIDE_VAULT, str(e))
 

--- a/src/alaya/vault.py
+++ b/src/alaya/vault.py
@@ -94,7 +94,7 @@ _SKIP_DIRS = {".zk", ".git", ".venv", "__pycache__"}
 def iter_vault_md(vault: Path):
     """Yield .md files in vault, skipping tooling directories and unreadable files."""
     for md_file in vault.rglob("*.md"):
-        if any(part in _SKIP_DIRS for part in md_file.parts):
+        if any(part in _SKIP_DIRS for part in md_file.relative_to(vault).parts):
             continue
         yield md_file
 

--- a/src/alaya/watcher.py
+++ b/src/alaya/watcher.py
@@ -68,8 +68,11 @@ class VaultEventHandler(FileSystemEventHandler):
             return False
 
     def _is_ignored(self, path: str) -> bool:
-        parts = Path(path).parts
-        return any(d in parts for d in _IGNORED_DIRS)
+        try:
+            rel = Path(path).relative_to(self.vault)
+        except ValueError:
+            return True
+        return any(d in rel.parts for d in _IGNORED_DIRS)
 
     def _relative(self, path: str) -> str:
         return str(Path(path).relative_to(self.vault))
@@ -95,6 +98,8 @@ class VaultEventHandler(FileSystemEventHandler):
                 return
             content = path.read_text()
             chunks = chunk_note(rel, content)
+            if not chunks:
+                return
             embeddings = embed_chunks(chunks)
             upsert_note(rel, chunks, embeddings, self.store)
         except Exception as e:

--- a/tests/unit/index/test_reindex.py
+++ b/tests/unit/index/test_reindex.py
@@ -137,6 +137,7 @@ class TestModelChangeDetection:
              patch("alaya.index.models.get_active_model") as mock_model:
             mock_model.return_value = MagicMock(name="nomic-ai/model-a", dimensions=768)
             mock_model.return_value.name = "model-a"
+            mock_model.return_value.key = "model-a"
             reindex_incremental(vault)
 
         # Verify state file records model-a
@@ -153,6 +154,7 @@ class TestModelChangeDetection:
              patch("alaya.index.models.get_active_model") as mock_model:
             mock_model.return_value = MagicMock(name="nomic-ai/model-b", dimensions=768)
             mock_model.return_value.name = "model-b"
+            mock_model.return_value.key = "model-b"
             result = reindex_incremental(vault)
 
         assert result.notes_indexed == 1  # re-embedded despite no content change

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -26,7 +26,7 @@ def test_maybe_start_reembed_no_op_when_models_match(tmp_path: Path) -> None:
     store = MagicMock()
     with patch("alaya.index.store.get_index_model", return_value="model-a"), \
          patch("alaya.index.models.get_active_model") as mock_active:
-        mock_active.return_value.name = "model-a"
+        mock_active.return_value.key = "model-a"
         threads_before = threading.active_count()
         _maybe_start_reembed(tmp_path, store)
         assert threading.active_count() == threads_before
@@ -36,7 +36,7 @@ def test_maybe_start_reembed_no_op_when_index_empty(tmp_path: Path) -> None:
     store = MagicMock()
     with patch("alaya.index.store.get_index_model", return_value=None), \
          patch("alaya.index.models.get_active_model") as mock_active:
-        mock_active.return_value.name = "model-a"
+        mock_active.return_value.key = "model-a"
         threads_before = threading.active_count()
         _maybe_start_reembed(tmp_path, store)
         assert threading.active_count() == threads_before
@@ -52,7 +52,7 @@ def test_maybe_start_reembed_spawns_thread_on_mismatch(tmp_path: Path) -> None:
     with patch("alaya.index.store.get_index_model", return_value="old-model"), \
          patch("alaya.index.models.get_active_model") as mock_active, \
          patch("alaya.index.reindex.reembed_background", side_effect=fake_reembed):
-        mock_active.return_value.name = "new-model"
+        mock_active.return_value.key = "new-model"
         _maybe_start_reembed(tmp_path, store)
         import time; time.sleep(0.05)
 


### PR DESCRIPTION
- iter_vault_md/watcher: check relative path parts, not absolute, so vaults under .git/.venv parent dirs are not silently skipped
- models: add key field to EmbeddingModelConfig so nomic-v1.5 and nomic-v1.5-q4 variants are distinguishable for cache/reindex/store
- delete_note: wrap entire operation (check + frontmatter + move) in a single lock to prevent concurrent data corruption
- rename_note: check dest.exists() before rename to prevent silent overwrite of existing notes
- watcher: guard embed_chunks with empty-chunk check to prevent numpy AxisError on blank .md files
- update_metadata: add new rows before deleting old ones so transient add failure does not permanently lose index data
- atomic_write: use tempfile.mkstemp for unique temp files instead of fixed .tmp suffix that collides between same-stem files
- move_note: move existence check inside the lock to close TOCTOU race