### PR TITLE
fix: code review round 5 — re.sub crash, permissions, chunk duplication

### DIFF
--- a/src/alaya/index/store.py
+++ b/src/alaya/index/store.py
@@ -193,11 +193,15 @@ def update_metadata(
             row.pop("_distance", None)
             updated.append(row)
 
-        # Add new rows before deleting old ones — brief duplication is
-        # harmless, but losing rows on a failed add is not recoverable.
-        table.add(updated)
+        # When paths differ, add first to avoid data loss on failure.
+        # When paths are equal, we must delete first since old and new
+        # rows share the same path and can't be distinguished.
         if old_path != new_path:
+            table.add(updated)
             table.delete(f"path = '{_sq(old_path)}'")
+        else:
+            table.delete(f"path = '{_sq(old_path)}'")
+            table.add(updated)
     except _STORE_ERRORS as e:
         logger.warning("Failed to update metadata for %s: %s", old_path, e)
 
@@ -229,7 +233,7 @@ def hybrid_search(
         if tags:
             for tag in tags:
                 # tags column is comma-bounded (e.g. ",python,web,"); match whole tags
-                filters.append(f"tags LIKE '%,{_sq_like(tag)},%'")
+                filters.append(f"tags LIKE '%,{_sq_like(tag)},%' ESCAPE '\\'")
         if since:
             filters.append(f"modified_date >= '{_sq(since)}'")
         if filters:

--- a/src/alaya/tools/_locks.py
+++ b/src/alaya/tools/_locks.py
@@ -7,6 +7,7 @@ writes on the same file.
 Only protects within a single process — sufficient for the MCP server model.
 """
 import os
+import stat
 import tempfile
 import threading
 from pathlib import Path
@@ -39,6 +40,8 @@ def atomic_write(path: Path, content: str) -> None:
     tmp = Path(tmp_name)
     try:
         os.close(fd)
+        if path.exists():
+            os.chmod(tmp_name, stat.S_IMODE(path.stat().st_mode))
         tmp.write_text(content)
         tmp.replace(path)
     except Exception:

--- a/src/alaya/tools/structure.py
+++ b/src/alaya/tools/structure.py
@@ -133,7 +133,7 @@ def rename_note(relative_path: str, new_title: str, vault: Path) -> str:
             raise FileExistsError(f"A note already exists at {dest.relative_to(vault)}")
 
         # update frontmatter title then rename atomically
-        content = re.sub(r"^title:.*$", f"title: {new_title}", content, count=1, flags=re.MULTILINE)
+        content = re.sub(r"^title:.*$", lambda m: f"title: {new_title}", content, count=1, flags=re.MULTILINE)
         atomic_write(src, content)
         src.rename(dest)
 


### PR DESCRIPTION
- rename_note: use lambda replacement in re.sub to prevent backslash sequences in titles from being interpreted as backreferences
- atomic_write: preserve original file permissions instead of mkstemp defaulting to 0o600 (fixes spurious git permission diffs)
- update_metadata: fix chunk duplication when old_path == new_path by delete-then-add for same-path updates, add-then-delete for moves
- hybrid_search: add ESCAPE clause to LIKE filter so DataFusion interprets \_ and \% as literal escapes