### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest -x --tb=short -q -m "not integration"
+
+  build:
+    name: Build distribution
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test test-unit test-integration lint serve
+.PHONY: help install test test-unit test-integration lint serve publish
 .DEFAULT_GOAL := help
 
 help:
@@ -26,3 +26,8 @@ lint: ## Lint source and tests
 
 serve: ## Start the server
 	uv run alaya
+
+##@ Publishing
+publish: ## Build distribution and check with twine
+	uv build
+	uv tool run twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,17 @@ version = "0.1.0"
 description = "A second brain -- FastMCP server for personal knowledge vaults (zk and Obsidian)"
 readme = "README.md"
 requires-python = ">=3.12"
+license = {text = "Apache-2.0"}
+authors = [{name = "Luke Kucing"}]
+keywords = ["mcp", "knowledge-base", "zettelkasten", "obsidian", "rag"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Text Processing :: General",
+]
 dependencies = [
     "fastmcp>=3.0.2",
     "lancedb>=0.29",
@@ -37,6 +48,10 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (require real zk binary and vault)",
 ]
+
+[project.urls]
+Repository = "https://github.com/luke-kucing/alaya"
+Issues = "https://github.com/luke-kucing/alaya/issues"
 
 [project.scripts]
 alaya = "alaya.server:main"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/publish.yml`) triggered on `v*` tag pushes with three chained jobs: test, build, publish
- Uses PyPI trusted publishing (OIDC) via `pypa/gh-action-pypi-publish@release/v1` — no API tokens needed
- Add PyPI metadata to `pyproject.toml`: license, authors, keywords, classifiers, project URLs
- Add `make publish` target for local build verification (`uv build` + `twine check`)

## Test plan
- [x] `uv build` produces sdist + wheel locally
- [x] `uv tool run twine check dist/*` passes on both artifacts
- [ ] After merge, configure trusted publisher on pypi.org:
  - Owner: `luke-kucing`, Repo: `alaya`, Workflow: `publish.yml`, Environment: `pypi`
- [ ] Create `pypi` environment in GitHub repo settings
- [ ] Tag and push: `git tag v0.1.0 && git push origin v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)